### PR TITLE
removed protocol on the Google Font URL

### DIFF
--- a/css/post.scss
+++ b/css/post.scss
@@ -2,7 +2,7 @@
 # Front matter comment to ensure Jekyll properly reads file.
 ---
 
-@import url(http://fonts.googleapis.com/css?family=Ubuntu);
+@import url(//fonts.googleapis.com/css?family=Ubuntu);
 
 body {
   margin: 0;

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -2,7 +2,7 @@
 # Front matter comment to ensure Jekyll properly reads file.
 ---
 
-@import url(http://fonts.googleapis.com/css?family=Ubuntu);
+@import url(//fonts.googleapis.com/css?family=Ubuntu);
 
 body {
   margin: 0;


### PR DESCRIPTION
making sure Google Fonts is served over the https channel to prevent the mixed content errors.
